### PR TITLE
Add support for TrackOpens and TrackLinks

### DIFF
--- a/demo/Network/Api/Postmark/Demo.hs
+++ b/demo/Network/Api/Postmark/Demo.hs
@@ -16,6 +16,8 @@ fakeemail = defaultEmail {
   , emailSubject = "demo, yes it really is a demo"
   , emailTag = Just "demo"
   , emailHtml = Just "Hello world!"
+  , emailTrackOpens = Just True
+  , emailTrackLinks = Just HtmlOnly
   , emailReplyTo = "demo-reply-to@postmark.hs"
   }
 

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -32,8 +32,17 @@ data Email = Email {
   , emailText :: Maybe Text
   , emailReplyTo :: Text
   , emailHeaders :: Map Text Text
+  , emailTrackOpens :: Maybe Bool
+  , emailTrackLinks :: Maybe TrackLinks
   , emailAttachments :: [Attachment]
   }
+
+data TrackLinks
+  = None
+  | HtmlAndText
+  | HtmlOnly
+  | TextOnly
+  deriving (Show)
 
 data Attachment = Attachment {
     attachmentName :: Text
@@ -52,6 +61,8 @@ data EmailWithTemplate = EmailWithTemplate {
   , emailTag' :: Maybe Text
   , emailReplyTo' :: Text
   , emailHeaders' :: Map Text Text
+  , emailTrackOpens' :: Maybe Bool
+  , emailTrackLinks' :: Maybe TrackLinks
   , emailAttachments' :: [Attachment]
   }
 
@@ -67,6 +78,8 @@ defaultEmail = Email {
   , emailText = Nothing
   , emailReplyTo = ""
   , emailHeaders = M.empty
+  , emailTrackOpens = Nothing
+  , emailTrackLinks = Nothing
   , emailAttachments = []
   }
 
@@ -82,6 +95,8 @@ defaultEmailWithTemplate = EmailWithTemplate {
   , emailTag' = Nothing
   , emailReplyTo' = ""
   , emailHeaders' = M.empty
+  , emailTrackOpens' = Nothing
+  , emailTrackLinks' = Nothing
   , emailAttachments' = []
   }
 
@@ -98,8 +113,13 @@ instance ToJSON Email where
     , oljson "Cc" (emailCc v) (T.intercalate ",")
     , oljson "Bcc" (emailBcc v) (T.intercalate ",")
     , omjson "Headers" (emailHeaders v)
+    , ojson "TrackOpens" (emailTrackOpens v)
+    , ojson "TrackLinks" (emailTrackLinks v)
     , oljson "Attachments" (emailAttachments v) id
     ])
+
+instance ToJSON TrackLinks where
+  toJSON a = String (pack . show $ a)
 
 instance ToJSON Attachment where
   toJSON v = object [
@@ -120,6 +140,8 @@ instance ToJSON EmailWithTemplate where
     , oljson "Cc" (emailCc' v) (T.intercalate ",")
     , oljson "Bcc" (emailBcc' v) (T.intercalate ",")
     , omjson "Headers" (emailHeaders' v)
+    , ojson "TrackOpens" (emailTrackOpens' v)
+    , ojson "TrackLinks" (emailTrackLinks' v)
     , oljson "Attachments" (emailAttachments' v) id
     ])
 -- * Response types

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -119,7 +119,7 @@ instance ToJSON Email where
     ])
 
 instance ToJSON TrackLinks where
-  toJSON a = String (pack . show $ a)
+  toJSON = String . pack . show
 
 instance ToJSON Attachment where
   toJSON v = object [

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -118,8 +118,15 @@ instance ToJSON Email where
     , oljson "Attachments" (emailAttachments v) id
     ])
 
+{- The reason we are being explicit here is because the serialized constructors
+   for TrackLinks match the possible values in the Postmark API.
+   We don't want to send values wholesale if new constructors come along.
+-}
 instance ToJSON TrackLinks where
-  toJSON = String . pack . show
+  toJSON None = String . pack . show $ None
+  toJSON HtmlAndText = String . pack . show $ HtmlAndText
+  toJSON HtmlOnly = String . pack . show $ HtmlOnly
+  toJSON TextOnly = String . pack . show $ TextOnly
 
 instance ToJSON Attachment where
   toJSON v = object [


### PR DESCRIPTION
Hi @markhibberd and @novemberkilo,

As per the issue #4 , this PR adds support fot `TrackOpens` and `TrackLinks` in both the "send and email" API and the "send an email using a template" API.

One note — `TrackLinks` is a sum-type and relies on the `Show` instance for getting the corresponding values in the Postmark API. I think it makes sense, because the possible values for `TrackOpens` in the Postmark API are exactly the string equivalents of the `TrackLinks` constructors, and neither are likely to change soon.

Let me know if anything needs changing.

Cheers and thanks for the library!