### PR TITLE
Documentation

### DIFF
--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -20,7 +20,32 @@
 --
 -- Issues can be reported at <https://github.com/apiengine/postmark/issues>.
 --
-module Network.Api.Postmark (module X) where
+module Network.Api.Postmark (
+
+  -- * Core
+  email, emails, emailWithTemplate, request,
+
+  -- * Data
+  Email (..), TrackLinks (..), Attachment (..),
+  EmailWithTemplate (..), defaultEmail, defaultEmailWithTemplate,
+  Sent (..),
+
+  -- * Error
+  PostmarkError (..), PostmarkErrorType (..),
+
+  -- * Request
+  PostmarkRequest (..), PostmarkRequest',
+
+  -- * Response
+  PostmarkResponse (..), PostmarkUnexpectedType (..),
+  PostmarkResponse', syntaxErr, formatErr,
+
+  -- * Settings
+  PostmarkSettings (..), postmarkTestToken,
+  postmarkHttpTest, postmarkHttpsTest,
+  postmarkHttp, postmarkHttps
+
+) where
 
 import Network.Api.Postmark.Core as X
 import Network.Api.Postmark.Data as X hiding (ojson, oljson, omjson, toText)

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -7,7 +7,7 @@
 --
 -- Library for postmarkapp.com HTTP Api.
 --
--- To get start see some examples in the 'Network.Api.Postmark.Tutorial' module at <http://hackage.haskell.org/packages/archive/postmark/0.0.2/doc/html/Network-Api-Postmark-Tutorial.html>.
+-- To get start see some examples in the "Network.Api.Postmark.Tutorial" module.
 --
 -- Source and more information can be found at <https://github.com/apiengine/postmark>.
 --

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -50,9 +50,9 @@ module Network.Api.Postmark (
 
 ) where
 
-import Network.Api.Postmark.Core as X
-import Network.Api.Postmark.Data as X hiding (ojson, oljson, omjson, toText)
-import Network.Api.Postmark.Error as X
-import Network.Api.Postmark.Request as X
-import Network.Api.Postmark.Response as X
-import Network.Api.Postmark.Settings as X
+import Network.Api.Postmark.Core
+import Network.Api.Postmark.Data
+import Network.Api.Postmark.Error
+import Network.Api.Postmark.Request
+import Network.Api.Postmark.Response
+import Network.Api.Postmark.Settings

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -29,21 +29,21 @@ module Network.Api.Postmark (
 
   -- * Sending email
   email, emails, Email (..), defaultEmail,
-
   -- ** Using a template
   emailWithTemplate, EmailWithTemplate (..), defaultEmailWithTemplate,
-
-  -- ** Ancillary types
-  TrackLinks (..), Attachment (..), Sent (..),
+  -- ** Tracking links
+  TrackLinks (..),
+  -- ** Attachments
+  Attachment (..),
+  -- ** Response type
+  Sent (..),
 
   -- * Error types
   PostmarkError (..), PostmarkErrorType (..),
 
   -- * Lower-level API
-
   -- ** Request
   request, PostmarkRequest (..), PostmarkRequest',
-
   -- ** Response
   PostmarkResponse (..), PostmarkUnexpectedType (..),
   PostmarkResponse', syntaxErr, formatErr,

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -22,29 +22,31 @@
 --
 module Network.Api.Postmark (
 
-  -- * Core
-  email, emails, emailWithTemplate, request,
+  -- * Settings
+  PostmarkSettings (..), PostmarkApiToken, postmarkHttp, postmarkHttps,
+  -- ** Using the test token
+  postmarkTestToken, postmarkHttpTest, postmarkHttpsTest,
 
-  -- * Data
-  Email (..), TrackLinks (..), Attachment (..),
-  EmailWithTemplate (..), defaultEmail, defaultEmailWithTemplate,
-  Sent (..),
+  -- * Sending email
+  email, emails, Email (..), defaultEmail,
 
-  -- * Error
+  -- ** Using a template
+  emailWithTemplate, EmailWithTemplate (..), defaultEmailWithTemplate,
+
+  -- ** Ancillary types
+  TrackLinks (..), Attachment (..), Sent (..),
+
+  -- * Error types
   PostmarkError (..), PostmarkErrorType (..),
 
-  -- * Request
-  PostmarkRequest (..), PostmarkRequest',
+  -- * Lower-level API
 
-  -- * Response
+  -- ** Request
+  request, PostmarkRequest (..), PostmarkRequest',
+
+  -- ** Response
   PostmarkResponse (..), PostmarkUnexpectedType (..),
   PostmarkResponse', syntaxErr, formatErr,
-
-  -- * Settings
-  PostmarkSettings (..),
-  PostmarkApiToken, postmarkTestToken,
-  postmarkHttpTest, postmarkHttpsTest,
-  postmarkHttp, postmarkHttps
 
 ) where
 

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -12,6 +12,7 @@
 -- Source and more information can be found at <https://github.com/apiengine/postmark>.
 --
 -- To experiment with a live demo try:
+--
 -- > $ git clone https://github.com/apiengine/postmark
 -- > $ cd postmark
 -- > $ cabal install --only-dependencies &&  cabal configure -f demo  && cabal build

--- a/src/Network/Api/Postmark.hs
+++ b/src/Network/Api/Postmark.hs
@@ -41,7 +41,8 @@ module Network.Api.Postmark (
   PostmarkResponse', syntaxErr, formatErr,
 
   -- * Settings
-  PostmarkSettings (..), postmarkTestToken,
+  PostmarkSettings (..),
+  PostmarkApiToken, postmarkTestToken,
   postmarkHttpTest, postmarkHttpsTest,
   postmarkHttp, postmarkHttps
 

--- a/src/Network/Api/Postmark/Core.hs
+++ b/src/Network/Api/Postmark/Core.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Api.Postmark.Core (
+
+  -- * API endpoints
   email,
   emails,
   emailWithTemplate,
+
+  -- * Run a request
   request
+
 ) where
 
 import qualified Data.ByteString.Lazy as BL

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -1,11 +1,23 @@
 {-# LANGUAGE OverloadedStrings, GADTSyntax #-}
 module Network.Api.Postmark.Data (
+
+  -- * Request types
+
+  -- ** Email
   Email (..),
-  TrackLinks (..),
-  Attachment (..),
-  EmailWithTemplate (..),
   defaultEmail,
+
+  -- ** Email with template
+  EmailWithTemplate (..),
   defaultEmailWithTemplate,
+
+  -- ** Track links
+  TrackLinks (..),
+
+  -- ** Attachment
+  Attachment (..),
+
+  -- ** Sent
   Sent (..),
 
   -- * Internal Json tools

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -1,5 +1,19 @@
 {-# LANGUAGE OverloadedStrings, GADTSyntax #-}
-module Network.Api.Postmark.Data where
+module Network.Api.Postmark.Data (
+  Email (..),
+  TrackLinks (..),
+  Attachment (..),
+  EmailWithTemplate (..),
+  defaultEmail,
+  defaultEmailWithTemplate,
+  Sent (..),
+
+  -- * Internal Json tools
+  ojson,
+  oljson,
+  omjson,
+  toText
+) where
 
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text.Lazy as LT

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -17,7 +17,7 @@ module Network.Api.Postmark.Data (
   -- ** Attachment
   Attachment (..),
 
-  -- ** Sent
+  -- ** Response type
   Sent (..),
 
   -- * Internal Json tools
@@ -190,6 +190,7 @@ instance ToJSON EmailWithTemplate where
     , ojson "TrackLinks" (emailTrackLinks' v)
     , oljson "Attachments" (emailAttachments' v) id
     ])
+
 -- * Response types
 
 data Sent =

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -63,11 +63,18 @@ data Email = Email {
   , emailAttachments :: [Attachment]
   }
 
+-- | When “link tracking” is enabled, Postmark will record statistics when a
+-- user clicks on a link in an email. You can use this feature to determine
+-- if a particular recipient has clicked a link that was emailed to them.
+--
+-- https://postmarkapp.com/developer/user-guide/tracking-links#enabling-link-tracking
 data TrackLinks
-  = None
-  | HtmlAndText
-  | HtmlOnly
-  | TextOnly
+  = None        -- ^ No links will be replaced or tracked.
+  | HtmlAndText -- ^ Links will be replaced in both HTML and text bodies.
+  | HtmlOnly    -- ^ Links will be replaced in only the HTML body. You may
+                --   want this option if you do not want encoded tracking
+                --   links to appear in the plain text of an email.
+  | TextOnly    -- ^ Links will be replaced in only the text body.
   deriving (Show)
 
 data Attachment = Attachment {

--- a/src/Network/Api/Postmark/Error.hs
+++ b/src/Network/Api/Postmark/Error.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE OverloadedStrings, GADTSyntax #-}
-module Network.Api.Postmark.Error where
+module Network.Api.Postmark.Error (
+  PostmarkError (..),
+  PostmarkErrorType (..)
+) where
 
 import Data.Aeson
 import Data.Text

--- a/src/Network/Api/Postmark/Request.hs
+++ b/src/Network/Api/Postmark/Request.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE GADTs, GADTSyntax #-}
-module Network.Api.Postmark.Request where
+module Network.Api.Postmark.Request (
+  PostmarkRequest (..),
+  PostmarkRequest'
+) where
 
 import Network.Api.Postmark.Error
 

--- a/src/Network/Api/Postmark/Response.hs
+++ b/src/Network/Api/Postmark/Response.hs
@@ -1,4 +1,10 @@
-module Network.Api.Postmark.Response where
+module Network.Api.Postmark.Response (
+  PostmarkResponse (..),
+  PostmarkUnexpectedType (..),
+  PostmarkResponse',
+  syntaxErr,
+  formatErr
+) where
 
 import qualified Data.ByteString.Lazy as BL
 import Data.Text

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -19,6 +19,10 @@ data PostmarkSettings =
     , apiToken :: PostmarkApiToken
     } deriving (Eq, Show)
 
+-- | An API token that you can use when you want to send test emails that
+-- don't actually get delivered to the recipient.
+--
+-- https://postmarkapp.com/developer/api/overview#authentication
 postmarkTestToken :: PostmarkApiToken
 postmarkTestToken = "POSTMARK_API_TEST"
 

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -1,12 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Api.Postmark.Settings (
+
+  -- * Settings types
   PostmarkSettings (..),
   PostmarkApiToken,
+
+  -- * Settings construction
+  postmarkHttp,
+  postmarkHttps,
+
+  -- * Using the test token
   postmarkTestToken,
   postmarkHttpTest,
-  postmarkHttpsTest,
-  postmarkHttp,
-  postmarkHttps
+  postmarkHttpsTest
+
 ) where
 
 import Data.Text

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -11,6 +11,15 @@ module Network.Api.Postmark.Settings (
 
 import Data.Text
 
+-- | The Postmark “server token” which is sent via the
+-- @X-Postmark-Server-Token@ HTTP header. You can find your server
+-- token under the “Credentials” tab on the Postmark website.
+--
+-- If you do not yet have a Postmark account, or if you want to send
+-- test emails that don't actually get delivered, you may use
+-- 'postmarkTestToken'.
+--
+-- https://postmarkapp.com/developer/api/overview#authentication
 type PostmarkApiToken = Text
 
 data PostmarkSettings =

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -26,14 +26,24 @@ data PostmarkSettings =
 postmarkTestToken :: PostmarkApiToken
 postmarkTestToken = "POSTMARK_API_TEST"
 
+-- | Postmark settings using the HTTP protocol and the test API token
+-- ('postmarkTestToken').
+--
+-- HTTPS is recommended instead ('postmarkHttpsTest').
 postmarkHttpTest :: PostmarkSettings
 postmarkHttpTest = postmarkHttp postmarkTestToken
 
+-- | Postmark settings using the HTTPS protocol and the test API token
+-- ('postmarkTestToken').
 postmarkHttpsTest :: PostmarkSettings
 postmarkHttpsTest = postmarkHttps postmarkTestToken
 
+-- | Constructs Postmark settings using the HTTP protocol and your API token.
+--
+-- HTTPS is recommended instead ('postmarkHttps').
 postmarkHttp :: PostmarkApiToken -> PostmarkSettings
 postmarkHttp = PostmarkSettings "http://api.postmarkapp.com"
 
+-- | Constructs Postmark settings using the HTTPS protocol and your API token.
 postmarkHttps :: PostmarkApiToken -> PostmarkSettings
 postmarkHttps = PostmarkSettings "https://api.postmarkapp.com"

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Network.Api.Postmark.Settings where
+module Network.Api.Postmark.Settings (
+  PostmarkSettings (..),
+  postmarkTestToken,
+  postmarkHttpTest,
+  postmarkHttpsTest,
+  postmarkHttp,
+  postmarkHttps
+) where
 
 import Data.Text
 

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Api.Postmark.Settings (
   PostmarkSettings (..),
+  PostmarkApiToken,
   postmarkTestToken,
   postmarkHttpTest,
   postmarkHttpsTest,
@@ -10,13 +11,15 @@ module Network.Api.Postmark.Settings (
 
 import Data.Text
 
+type PostmarkApiToken = Text
+
 data PostmarkSettings =
   PostmarkSettings {
       apiUrl :: Text
-    , apiToken :: Text
+    , apiToken :: PostmarkApiToken
     } deriving (Eq, Show)
 
-postmarkTestToken :: Text
+postmarkTestToken :: PostmarkApiToken
 postmarkTestToken = "POSTMARK_API_TEST"
 
 postmarkHttpTest :: PostmarkSettings
@@ -25,8 +28,8 @@ postmarkHttpTest = postmarkHttp postmarkTestToken
 postmarkHttpsTest :: PostmarkSettings
 postmarkHttpsTest = postmarkHttps postmarkTestToken
 
-postmarkHttp :: Text -> PostmarkSettings
+postmarkHttp :: PostmarkApiToken -> PostmarkSettings
 postmarkHttp = PostmarkSettings "http://api.postmarkapp.com"
 
-postmarkHttps :: Text -> PostmarkSettings
+postmarkHttps :: PostmarkApiToken -> PostmarkSettings
 postmarkHttps = PostmarkSettings "https://api.postmarkapp.com"

--- a/src/Network/Api/Postmark/Settings.hs
+++ b/src/Network/Api/Postmark/Settings.hs
@@ -22,6 +22,11 @@ import Data.Text
 -- https://postmarkapp.com/developer/api/overview#authentication
 type PostmarkApiToken = Text
 
+-- | To construct 'PostmarkSettings', use 'postmarkHttps' or
+-- 'postmarkHttp'.
+--
+-- Or to use the test API instead, use 'postmarkHttpsTest' or
+-- 'postmarkHttpTest'.
 data PostmarkSettings =
   PostmarkSettings {
       apiUrl :: Text


### PR DESCRIPTION
Adding a bit more documentation to your lovely library, I hope you like it :)

* Added explicit export lists to all the modules

* Organized the haddock headers on the main module:

```
Settings
    Using the test token
Sending email
    Using a template
    Tracking links
    Attachments
    Response type
Error types
Lower-level API
    Request
    Response
```

* Added a type alias `PostmarkApiToken = Text`

* Added haddocks on a handful of types and functions