### PR TITLE
Relax dependencies and support aeson-2.0

### DIFF
--- a/postmark.cabal
+++ b/postmark.cabal
@@ -22,6 +22,7 @@ Source-Repository   head
 Flag demo
     Description:   Build the demo executable.
     Default:       False
+    Manual:        True
 
 Library
   Build-Depends:

--- a/postmark.cabal
+++ b/postmark.cabal
@@ -61,7 +61,7 @@ executable         postmark-demo
         Buildable: False
 
     ghc-options:   -Wall -threaded
-    main-is:           ../demo/demo.hs
+    main-is:           demo.hs
     hs-source-dirs:    demo
     build-depends:     base
                      , postmark

--- a/postmark.cabal
+++ b/postmark.cabal
@@ -26,12 +26,12 @@ Flag demo
 Library
   Build-Depends:
                     base                            >= 3 && < 5
-                    , aeson                         >= 0.6 && < 2
-                    , attoparsec                    >= 0.10 && < 0.14
-                    , bytestring                    >= 0.9 && < 0.11
+                    , aeson                         >= 0.6 && < 2.1
+                    , attoparsec                    >= 0.10 && < 0.15
+                    , bytestring                    >= 0.9 && < 0.12
                     , containers                    >= 0.4 && < 0.7
                     , http-types                    >= 0.6 && < 1
-                    , text                          >= 0.11 && < 1.3
+                    , text                          >= 0.11 && < 1.4
                     , network-api-support           >= 0.3.0 && < 0.4
                     , http-client-tls               >= 0.2.1.1 && < 0.4
 

--- a/src/Network/Api/Postmark/Data.hs
+++ b/src/Network/Api/Postmark/Data.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings, GADTSyntax #-}
 module Network.Api.Postmark.Data (
 
@@ -210,13 +211,17 @@ instance FromJSON Sent where
 
 -- * Internal Json tools
 
-ojson :: ToJSON a => Text -> Maybe a -> Maybe (Text, Value)
+#if ! MIN_VERSION_aeson(2,0,0)
+type Key = Text
+#endif
+
+ojson :: ToJSON a => Key -> Maybe a -> Maybe (Key, Value)
 ojson k = fmap (k .=)
 
-oljson :: ToJSON b => Text -> [a] -> ([a] -> b) -> Maybe (Text, Value)
+oljson :: ToJSON b => Key -> [a] -> ([a] -> b) -> Maybe (Key, Value)
 oljson k vs f = if L.null vs then Nothing else Just (k .= f vs)
 
-omjson :: (ToJSON a) => Text -> Map Text a -> Maybe (Text, Value)
+omjson :: (ToJSON a) => Key -> Map Text a -> Maybe (Key, Value)
 omjson k vs = if M.null vs then Nothing else Just (k .= vs)
 
 toText :: BL.ByteString -> Text


### PR DESCRIPTION
This relaxes the restrictive upper bounds and adds support for `aeson-2.0`. It also avoids some packaging issues related to the `demo` executable.

See also https://github.com/markhibberd/network-api-support/pull/29
